### PR TITLE
Add publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish IDM Console Framework
+
+on:
+  push:
+    branches:
+      - v1
+
+jobs:
+  init:
+    name: Initialization
+    uses: ./.github/workflows/init.yml
+    secrets: inherit
+
+  build:
+    name: Waiting for build
+    needs: init
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Building IDM Console Framework'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+  publish:
+    name: Publishing IDM Console Framework
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retrieve idm-console-framework-dist image
+        uses: actions/cache@v3
+        with:
+          key: idm-console-framework-dist-${{ github.sha }}
+          path: idm-console-framework-dist.tar
+
+      - name: Publish idm-console-framework-dist image
+        run: |
+          docker load --input idm-console-framework-dist.tar
+          docker tag idm-console-framework-dist ghcr.io/${{ github.repository_owner }}/idm-console-framework-dist:1
+          docker push ghcr.io/${{ github.repository_owner }}/idm-console-framework-dist:1
+
+      - name: Retrieve idm-console-framework-runner image
+        uses: actions/cache@v3
+        with:
+          key: idm-console-framework-runner-${{ github.sha }}
+          path: idm-console-framework-runner.tar
+
+      - name: Publish idm-console-framework-runner image
+        run: |
+          docker load --input idm-console-framework-runner.tar
+          docker tag idm-console-framework-runner ghcr.io/${{ github.repository_owner }}/idm-console-framework-runner:1
+          docker push ghcr.io/${{ github.repository_owner }}/idm-console-framework-runner:1


### PR DESCRIPTION
A new job has been added to publish IDM Console Framework images to GH Packages after the build job is complete.