### PR TITLE
Build RPM with Maven

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -43,5 +43,44 @@ jobs:
       run: |
         dnf localinstall -y /tmp/RPMS/*
 
-    - name: Build IDM Console Framework
+    - name: Build with Ant
       run: ./build.sh
+
+    - name: Install JSS into local Maven repo
+      run: |
+        # get JSS <major>.<minor>.<update> version
+        JSS_VERSION=$(rpm -q --qf "%{version}" dogtag-jss)
+
+        # if built by COPR, jss-base.jar will be installed in /usr/lib/java,
+        # otherwise it will be in /usr/share/java.
+        JSS_BASE_JAR=$(find /usr/lib/java /usr/share/java -name jss-base.jar)
+
+        mvn install:install-file \
+            -Dfile=$JSS_BASE_JAR \
+            -DgroupId=org.dogtagpki.jss \
+            -DartifactId=jss-base \
+            -Dversion=$JSS_VERSION-SNAPSHOT \
+            -Dpackaging=jar \
+            -DgeneratePom=true
+
+    - name: Install LDAP JDK into local Maven repo
+      run: |
+        # get LDAP JDK <major>.<minor>.<update> version
+        LDAPJDK_VERSION=$(rpm -q --qf "%{version}" dogtag-ldapjdk)
+
+        mvn install:install-file \
+            -Dfile=/usr/share/java/ldapjdk.jar \
+            -DgroupId=org.dogtagpki.ldap-sdk \
+            -DartifactId=ldapjdk \
+            -Dversion=$LDAPJDK_VERSION-SNAPSHOT \
+            -Dpackaging=jar \
+            -DgeneratePom=true
+
+    - name: Build with Maven
+      run: mvn package
+
+    - name: Compare idm-console-framework.jar
+      run: |
+        jar tvf $HOME/build/idm-console-framework/release/jars/idm-console-framework.jar | awk '{print $8;}' | grep -v '/$' | sort | tee idm-console-framework.ant
+        jar tvf target/idm-console-framework.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort | tee idm-console-framework.maven
+        diff idm-console-framework.ant idm-console-framework.maven

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dogtagpki.console-framework</groupId>
+    <artifactId>console-framework</artifactId>
+    <version>${revision}</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <revision>2.1.0-SNAPSHOT</revision>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>5.5.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dogtagpki.ldap-sdk</groupId>
+            <artifactId>ldapjdk</artifactId>
+            <version>5.5.0-SNAPSHOT</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+        <finalName>idm-console-framework</finalName>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/OWNER/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
+        </repository>
+    </distributionManagement>
+
+</project>


### PR DESCRIPTION
The RPM spec file has been modified to use Maven dependencies and to build the binaries with Maven.

The build test has been updated to compare Ant-built binaries with Maven-built binaries.